### PR TITLE
Resolve warning for Swift 2.2

### DIFF
--- a/Demo/Demo/NotificationViewController.swift
+++ b/Demo/Demo/NotificationViewController.swift
@@ -28,7 +28,7 @@ class KeyboardNotificationViewController: UIViewController {
         super.viewWillAppear(animated)
         
         keyboardNotifications.forEach {
-            NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardEventNotified:", name: $0, object: nil)
+            NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(keyboardEventNotified(_:)), name: $0, object: nil)
         }
     }
     

--- a/KeyboardObserver/KeyboardObserver.swift
+++ b/KeyboardObserver/KeyboardObserver.swift
@@ -110,7 +110,7 @@ public class KeyboardObserver {
     
     public init() {
         KeyboardEventType.allEventNames().forEach {
-            NSNotificationCenter.defaultCenter().addObserver(self, selector: "notified:", name: $0, object: nil)
+            NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(notified(_:)), name: $0, object: nil)
         }
     }
     


### PR DESCRIPTION
This warning occured:

```
KeyboardObserver/KeyboardObserver/KeyboardObserver.swift:113:78: Use of string literal for Objective-C selectors is deprecated; use '#selector' instead
```

This is Swift 2.2 new selector syntax, and is it okay to merge to master?
