### PR TITLE
Change UIAnimationOptions to UIAnimationCurve

### DIFF
--- a/Demo/Demo/ObserverViewController.swift
+++ b/Demo/Demo/ObserverViewController.swift
@@ -26,7 +26,7 @@ final class KeyboardObserverViewController: UIViewController {
                 let distance = UIScreen.mainScreen().bounds.height - event.keyboardFrameEnd.origin.y
                 let bottom = distance >= s.bottomLayoutGuide.length ? distance : s.bottomLayoutGuide.length
                 
-                UIView.animateWithDuration(event.duration, delay: 0.0, options: [event.curve], animations:
+                UIView.animateWithDuration(event.duration, delay: 0.0, options: [event.options], animations:
                     { [weak self] () -> Void in
                         self?.textView.contentInset.bottom = bottom
                         self?.textView.scrollIndicatorInsets.bottom = bottom

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ override func viewWillDisappear(animated: Bool) {
 func keyboardEventNotified(notification: NSNotification) {
     guard let userInfo = notification.userInfo else { return }
     let keyboardFrameEnd = (userInfo[UIKeyboardFrameEndUserInfoKey] as! NSValue).CGRectValue()
-    let curve = UIViewAnimationOptions(rawValue: UInt(userInfo[UIKeyboardAnimationCurveUserInfoKey] as! NSNumber))
+    let options = UIViewAnimationOptions(rawValue: UInt(userInfo[UIKeyboardAnimationCurveUserInfoKey] as! NSNumber))
     let duration = NSTimeInterval(userInfo[UIKeyboardAnimationDurationUserInfoKey] as! NSNumber)
     let distance = UIScreen.mainScreen().bounds.height - keyboardFrameEnd.origin.y
     let bottom = distance >= bottomLayoutGuide.length ? distance : bottomLayoutGuide.length
 
-    UIView.animateWithDuration(duration, delay: 0.0, options: [curve], animations:
+    UIView.animateWithDuration(duration, delay: 0.0, options: [options], animations:
         { [weak self] () -> Void in
             self?.textView.contentInset.bottom = bottom
             self?.textView.scrollIndicatorInsets.bottom = bottom


### PR DESCRIPTION
The keyboard UINotification's curve is UIAnimationCurve. Currently it is implemented with UIAnimationOptions so fix it to correct type.

However, it is rare to use UIAnimationCurve directly. So, I created `options` computed property. You can use curve easily through this property.

And this pull request covers https://github.com/morizotter/KeyboardObserver/pull/3 .

resolve https://github.com/morizotter/KeyboardObserver/pull/3
