### PR TITLE
Rename enabled property into isEnabled.

### DIFF
--- a/KeyboardObserver/KeyboardObserver.swift
+++ b/KeyboardObserver/KeyboardObserver.swift
@@ -114,7 +114,7 @@ public typealias KeyboardEventClosure = ((_ event: KeyboardEvent) -> Void)
 
 open class KeyboardObserver {
     open var state = KeyboardState.initial
-    open var enabled = true
+    open var isEnabled = true
     fileprivate var eventClosures = [KeyboardEventClosure]()
     
     deinit {
@@ -154,7 +154,7 @@ internal extension KeyboardObserver {
             state = .shown
         }
 
-        if !enabled { return }
+        if !isEnabled { return }
         eventClosures.forEach { $0(event) }
     }
 }


### PR DESCRIPTION
In Swift, `enabled` property is usually declared as `isEnabled` e.g. UIControl, and according to [Swift API design guidelines](https://swift.org/documentation/api-design-guidelines/), it says "Uses of Boolean methods and properties should read as assertions about the receiver when the use is nonmutating, e.g. x.isEmpty, line1.intersects(line2)." ([You can refer to the Japanese-translated document](http://snoozelag.hatenablog.com/entry/2017/07/09/224243))

So, I post this pull request to rename the `enabled` property into `isEnabled`, but it breaks the current API. What do you think of this change?